### PR TITLE
feat: add workflow to build extension artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
       - main
 
 env:
-  VERSION: "${{inputs.VERSION || var.VERSION}}"
+  VERSION: "0.0.0"
 
 jobs:
   build-artifact:
@@ -37,6 +37,13 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+
+      - name: Determine VERSION
+        id: determine-version
+        run: |
+          echo ${{env.VERSION}}
+          echo "VERSION=${{ github.event.inputs.VERSION || 'default-version' }}" >> $GITHUB_ENV
+          echo ${{env.VERSION}}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Create Artifact
         run: |
-          zip -r TapToQR.zip addon
+          cd addon
+          zip -r ../TapToQR.zip ./*
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,15 @@ on:
     inputs:
       VERSION:
         description: "The version of the addon to build"
+        type: string
         required: false
 
   workflow_call:
     inputs:
       VERSION:
-        required: false
         description: "The version of the addon to build"
+        type: string
+        required: false
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,12 @@ jobs:
               echo "VERSION=${{ inputs.VERSION }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Update Version
+        run: |
+          jq --arg version "${{steps.determine-version.outputs.VERSION}}" '.version = $version' package.json > temp.json && mv temp.json package.json
+          cd addon
+          jq --arg version "${{steps.determine-version.outputs.VERSION}}" '.version = $version' manifest.json > temp.json && mv temp.json manifest.json
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ on:
 env:
   VERSION: "0.0.0"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && 'pull_request' || 'push' }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build-artifact:
     name: "Build TapToQR Artifact"
@@ -44,7 +48,15 @@ jobs:
         id: determine-version
         run: |
           echo ${{env.VERSION}}
-          echo "VERSION=${{ github.event.inputs.VERSION || 'default-version' }}" >> $GITHUB_ENV
+          
+          if [ -z "${{ inputs.VERSION }}" ]; then
+              echo "Using repository version"
+              echo "VERSION=${{ vars.VERSION }}" >> $GITHUB_ENV
+          else
+              echo "Using input version"
+              echo "VERSION=${{ inputs.VERSION }}" >> $GITHUB_ENV
+          fi
+          
           echo ${{env.VERSION}}
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,16 @@ name: "Build TapToQR Artifact"
 
 on:
   workflow_dispatch:
+    inputs:
+      VERSION:
+        description: "The version of the addon to build"
+        required: false
 
   workflow_call:
-
+    inputs:
+      VERSION:
+        required: false
+        description: "The version of the addon to build"
   push:
     branches:
       - main
@@ -12,6 +19,9 @@ on:
   pull_request:
     branches:
       - main
+
+env:
+  VERSION: "${{inputs.VERSION || var.VERSION}}"
 
 jobs:
   build-artifact:
@@ -40,10 +50,10 @@ jobs:
       - name: Create Artifact
         run: |
           cd addon
-          zip -r ../TapToQR.zip ./*
+          zip -r ../TapToQR-${{env.VERSION}}.zip ./*
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          path: 'TapToQR.zip'
+          path: 'TapToQR-${{env.VERSION}}.zip'
           name: 'TapToQR-addon'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: "Build TapToQR Artifact"
+
+on:
+  workflow_dispatch:
+
+  workflow_call:
+
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-artifact:
+    name: "Build TapToQR Artifact"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint code
+        run: npm run lint
+
+      - name: Webpack project
+        run: npm run webpack-prod
+
+      - name: Create Artifact
+        run: |
+          zip -r TapToQR.zip addon
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: 'TapToQR.zip'
+          name: 'TapToQR-addon'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,6 @@ on:
     branches:
       - main
 
-env:
-  VERSION: "0.0.0"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && 'pull_request' || 'push' }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
@@ -46,18 +43,16 @@ jobs:
 
       - name: Determine VERSION
         id: determine-version
-        run: |
-          echo ${{env.VERSION}}
-          
+        run: |         
           if [ -z "${{ inputs.VERSION }}" ]; then
               echo "Using repository version"
-              echo "VERSION=${{ vars.VERSION }}" >> $GITHUB_ENV
+              echo ${{ vars.VERSION }}
+              echo "VERSION=${{ vars.VERSION }}" >> $GITHUB_OUTPUT
           else
               echo "Using input version"
-              echo "VERSION=${{ inputs.VERSION }}" >> $GITHUB_ENV
+              echo ${{ inputs.VERSION }}
+              echo "VERSION=${{ inputs.VERSION }}" >> $GITHUB_OUTPUT
           fi
-          
-          echo ${{env.VERSION}}
 
       - name: Install dependencies
         run: npm install
@@ -71,10 +66,10 @@ jobs:
       - name: Create Artifact
         run: |
           cd addon
-          zip -r ../TapToQR-${{env.VERSION}}.zip ./*
+          zip -r ../TapToQR-${{steps.determine-version.outputs.VERSION}}.zip ./*
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          path: 'TapToQR-${{env.VERSION}}.zip'
+          path: 'TapToQR-${{steps.determine-version.outputs.VERSION}}.zip'
           name: 'TapToQR-addon'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: "Release TapToQR"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        description: Which type of release to create?
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  # Get the Current Version and Bump it depending on the release-type input
+  update-version:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    outputs:
+      new_version: ${{ steps.bump_version.outputs.new_version }}
+    steps:
+      - name: Ensure branch is main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          text="Publish a new version can only be done from the main branch."
+          echo "::error title=Wrong Branch::$text"
+          exit 1
+
+      - name: Read current version
+        run: |
+          echo "Current version: ${{ vars.VERSION }}"
+
+      - name: Bump version
+        id: bump_version
+        run: |
+          # Retrieve the increment type from the GitHub Actions input
+          increment="${{ inputs.release-type }}"
+          
+          # Split the VERSION variable into its major, minor, and patch components
+          IFS='.' read -r -a parts <<< "${{ vars.VERSION }}"
+          
+          # Check if the VERSION variable was split correctly
+          if [ "${#parts[@]}" -ne 3 ]; then
+          echo "Invalid version format"
+          exit 1
+          fi
+          
+          major=${parts[0]}
+          minor=${parts[1]}
+          patch=${parts[2]}
+          
+          # Increment the appropriate version component
+          if [ "$increment" = "major" ]; then
+          major=$((major + 1))
+          minor=0
+          patch=0
+          elif [ "$increment" = "minor" ]; then
+          minor=$((minor + 1))
+          patch=0
+          elif [ "$increment" = "patch" ]; then
+          patch=$((patch + 1))
+          else
+          echo "Invalid increment type"
+          exit 1
+          fi
+          
+          # Construct the new version string
+          new_version="$major.$minor.$patch"
+          
+          # Output the new version
+          echo "New version: $new_version"
+          
+          # Set the output variable for GitHub Actions
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Update version var
+        id: write_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh variable set VERSION --body "${{ steps.bump_version.outputs.new_version }}"

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -22,11 +22,11 @@
             "matches": ["<all_urls>"]
         }
     ],
-    
+
     "content_security_policy": {
         "extension_pages": "script-src 'self'; object-src 'self';"
     },
-    
+
     "action": {
         "default_popup": "popup/tap-to-qr.html",
         "default_area": "navbar"
@@ -40,5 +40,4 @@
             "id": "taptoqr@moritzreis.dev"
         }
     }
-
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Instantly generate and share a QR code for the webpage you're currently viewing, making link sharing seamless and quick.",
   "scripts": {
     "build": "webpack --config prod.webpack.config.js",
+    "webpack-prod": "webpack --config prod.webpack.config.js",
     "lint": "cd addon && web-ext lint",
     "dev": "webpack --config prod.webpack.config.js && cd addon && web-ext run --start-url https://mozilla.org --browser-console"
   },


### PR DESCRIPTION
This pull request introduces new workflows for building and releasing the TapToQR addon, along with minor changes to the project configuration files. The most important changes include the addition of a build workflow, a release workflow, and updates to the `package.json` scripts.

### New workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R81): Added a workflow to build the TapToQR artifact, which includes steps for checking out the code, setting up Node.js, determining the version, updating the version in `package.json` and `manifest.json`, installing dependencies, linting the code, running webpack, and creating and uploading the artifact.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R87): Added a workflow to release the TapToQR addon, which includes steps for ensuring the branch is `main`, reading the current version, bumping the version based on the release type input, and updating the version variable in GitHub.

### Project configuration updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R7): Added a new script `webpack-prod` for running webpack with the production configuration.

### Minor changes:

* [`addon/manifest.json`](diffhunk://#diff-e28ef6b57b7b8904c2e950ab1ac7b848cd102cbac91a8a7a23e8ad276872402cL43): Removed an unnecessary empty line.