### PR TITLE
Feature/release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
 
+    outputs:
+      VERSION:
+        description: "The version of the addon to build"
+        value: ${{ jobs.build-artifact.outputs.VERSION }}
+
   workflow_call:
     inputs:
       VERSION:
@@ -30,6 +35,9 @@ jobs:
   build-artifact:
     name: "Build TapToQR Artifact"
     runs-on: ubuntu-latest
+
+    outputs:
+      VERSION: ${{ steps.determine-version.outputs.VERSION }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,17 +8,17 @@ on:
         type: string
         required: false
 
-    outputs:
-      VERSION:
-        description: "The version of the addon to build"
-        value: ${{ jobs.build-artifact.outputs.VERSION }}
-
   workflow_call:
     inputs:
       VERSION:
         description: "The version of the addon to build"
         type: string
         required: false
+    outputs:
+      VERSION:
+        description: "The version of the addon to build"
+        value: ${{ jobs.build-artifact.outputs.VERSION }}
+
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-#      - name: Ensure branch is main
-#        if: github.ref != 'refs/heads/main'
-#        run: |
-#          text="Publish a new version can only be done from the main branch."
-#          echo "::error title=Wrong Branch::$text"
-#          exit 1
+      - name: Ensure branch is main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          text="Publish a new version can only be done from the main branch."
+          echo "::error title=Wrong Branch::$text"
+          exit 1
 
       - name: Read current version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,35 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v4
 
-      - name: Create Release
-        working-directory: './TapToQR-addon'
-        env:
-          GH_TOKEN: ${{github.token}}
-        run: |
-          echo "Creating release v${{needs.update-version.outputs.new_version}}"
-          gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
-          gh release upload v${{needs.update-version.outputs.new_version}} TapToQR-${{needs.update-version.outputs.new_version}}.zip
+#      - name: Create Release
+#        working-directory: './TapToQR-addon'
+#        env:
+#          GH_TOKEN: ${{github.token}}
+#        run: |
+#          echo "Creating release v${{needs.update-version.outputs.new_version}}"
+#          gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
+#          gh release upload v${{needs.update-version.outputs.new_version}} TapToQR-${{needs.update-version.outputs.new_version}}.zip
+
+  release-firefox:
+    runs-on: ubuntu-latest
+    name: "Create TapToQR Firefox Release"
+    permissions: write-all
+    needs:
+      [
+        build,
+        update-version
+      ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+
+      - uses: wdzeng/firefox-addon@a6c520c
+        with:
+          addon-guid: "taptoqr@moritzreis.dev"
+          xpi-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          self-hosted: false
+          jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,5 +121,6 @@ jobs:
           GH_TOKEN: ${{github.token}}
         run: |
           echo "Creating release v${{needs.update-version.outputs.new_version}}"
+          ls
           gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
           gh release upload v${{needs.update-version.outputs.new_version}} .\TapToQR-${{needs.update-version.outputs.new_version}}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,11 @@ jobs:
       - name: "Upload to Chrome Webstore"
         run: |-
           cd TapToQR-addon
+          
+          # unzip the artifact
+          unzip TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          ls -R
+          
           chrome-webstore-upload \\
             --source TapToQR-${{needs.update-version.outputs.new_version}}.zip \\
             --extension-id "ommdikomjapdndpedljobeecepeopjmp" \\

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,3 +88,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.VAR_UPDATE_GITHUB }}
         run: |
           gh variable set VERSION --body "${{ steps.bump_version.outputs.new_version }}"
+
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      VERSION: ${{ needs.update-version.outputs.new_version }}
+    needs:
+      [
+        update-version
+      ]
+
+  release:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    needs:
+      [
+        build
+      ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+
+      - name: Create Release
+        working-directory: './StatusSwift'
+        env:
+          GH_TOKEN: ${{github.token}}
+        run: |
+          ls -R
+          
+          # gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
+          
+          # Compress-Archive -Path .\AppPackages -DestinationPath .\AppPackages.zip
+          # gh release upload v${{needs.update-version.outputs.new_version}} .\AppPackages.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
   # Get the Current Version and Bump it depending on the release-type input
   update-version:
     name: "Update TapToQR Version"
-    if: ${{ !github.event.inputs.skip-update }}
     runs-on: ubuntu-latest
     permissions: write-all
     outputs:
@@ -55,12 +54,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Ensure branch is main
-        if: github.ref != 'refs/heads/main'
-        run: |
-          text="Publish a new version can only be done from the main branch."
-          echo "::error title=Wrong Branch::$text"
-          exit 1
+#      - name: Ensure branch is main
+#        if: github.ref != 'refs/heads/main'
+#        run: |
+#          text="Publish a new version can only be done from the main branch."
+#          echo "::error title=Wrong Branch::$text"
+#          exit 1
 
       - name: Read current version
         run: |
@@ -68,6 +67,7 @@ jobs:
 
       - name: Bump version
         id: bump_version
+        if: ${{ !github.event.inputs.skip-update }}
         run: |
           # Retrieve the increment type from the GitHub Actions input
           increment="${{ inputs.release-type }}"
@@ -111,6 +111,7 @@ jobs:
 
       - name: Update version var
         id: write_version
+        if: ${{ !github.event.inputs.skip-update }}
         env:
           GITHUB_TOKEN: ${{ secrets.VAR_UPDATE_GITHUB }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       skip-update:
         type: boolean
         description: "Skip the version update step"
-        required: false
+        required: true
         default: false
       release-type:
         type: choice
@@ -20,22 +20,22 @@ on:
       publish-firefox:
         type: boolean
         description: Should the Firefox Addon be published?
-        required: false
+        required: true
         default: true
       publish-chrome:
         type: boolean
         description: Should the Chrome Extension be published?
-        required: false
+        required: true
         default: true
       publish-edge:
         type: boolean
         description: Should the Edge Extension be published?
-        required: false
+        required: true
         default: true
       publish-github:
         type: boolean
         description: Should the Github Release be published?
-        required: false
+        required: true
         default: true
 
 concurrency:
@@ -148,9 +148,9 @@ jobs:
         env:
           GH_TOKEN: ${{github.token}}
         run: |
-          echo "Creating release v${{needs.update-version.outputs.new_version}}"
-          gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
-          gh release upload v${{needs.update-version.outputs.new_version}} TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          echo "Creating release v${{needs.build.outputs.VERSION}}"
+          gh release create v${{needs.build.outputs.VERSION}} --generate-notes
+          gh release upload v${{needs.build.outputs.VERSION}} TapToQR-${{needs.build.outputs.VERSION}}.zip
 
   release-firefox:
     runs-on: ubuntu-latest
@@ -172,7 +172,7 @@ jobs:
         name: "Upload to Firefox Addon Store"
         with:
           addon-guid: "taptoqr@moritzreis.dev"
-          xpi-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          xpi-path: TapToQR-addon/TapToQR-${{needs.build.outputs.VERSION}}.zip
           self-hosted: false
           jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
           jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}
@@ -208,8 +208,8 @@ jobs:
         run: |-
           cd TapToQR-addon
 
-          unzip TapToQR-${{needs.update-version.outputs.new_version}}.zip
-          rm TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          unzip TapToQR-${{needs.build.outputs.VERSION}}.zip
+          rm TapToQR-${{needs.build.outputs.VERSION}}.zip
 
           chrome-webstore-upload
 
@@ -232,6 +232,6 @@ jobs:
       - uses: wdzeng/edge-addon@d4db1eea77297a24d799394dec87e8912e0902f9
         with:
           product-id: "1cc708c2-05e8-4339-9fdb-ddca04acf678"
-          zip-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          zip-path: TapToQR-addon/TapToQR-${{needs.build.outputs.VERSION}}.zip
           api-key: ${{ secrets.MICROSOFT_API_KEY }}
           client-id: ${{ secrets.MICROSOFT_CLIENT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   # Get the Current Version and Bump it depending on the release-type input
   update-version:
+    name: "Update TapToQR Version"
     runs-on: ubuntu-latest
     permissions: write-all
     outputs:
@@ -100,6 +101,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    name: "Create TapToQR Release"
     permissions: write-all
     needs:
       [
@@ -113,7 +115,6 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Create Release
-        working-directory: './StatusSwift'
         env:
           GH_TOKEN: ${{github.token}}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,8 @@ jobs:
     permissions: write-all
     needs:
       [
-        build
+        build,
+        update-version
       ]
     steps:
       - name: Checkout code
@@ -119,5 +120,6 @@ jobs:
         env:
           GH_TOKEN: ${{github.token}}
         run: |
+          echo "Creating release v${{needs.update-version.outputs.new_version}}"
           gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
           gh release upload v${{needs.update-version.outputs.new_version}} .\TapToQR-${{needs.update-version.outputs.new_version}}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,5 @@ jobs:
           GH_TOKEN: ${{github.token}}
         run: |
           echo "Creating release v${{needs.update-version.outputs.new_version}}"
-          ls
           gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
-          gh release upload v${{needs.update-version.outputs.new_version}} .\TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          gh release upload v${{needs.update-version.outputs.new_version}} TapToQR-${{needs.update-version.outputs.new_version}}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,6 @@ jobs:
   release-firefox:
     runs-on: ubuntu-latest
     name: "Create TapToQR Firefox Release"
-    permissions: write-all
     needs:
       [
         build,
@@ -152,7 +151,6 @@ jobs:
   release-chrome:
     runs-on: ubuntu-latest
     name: "Create TapToQR Chrome Release"
-    permissions: write-all
     needs:
       [
         build,
@@ -176,11 +174,26 @@ jobs:
         run: |
           npm install -g chrome-webstore-upload-cli
 
-      - name: "Upload to Chrome Webstore"
-        run: |-
-          cd TapToQR-addon
-          
-          unzip TapToQR-${{needs.update-version.outputs.new_version}}.zip
-          rm TapToQR-${{needs.update-version.outputs.new_version}}.zip
-          
-          chrome-webstore-upload
+#      - name: "Upload to Chrome Webstore"
+#        run: |-
+#          cd TapToQR-addon
+#
+#          unzip TapToQR-${{needs.update-version.outputs.new_version}}.zip
+#          rm TapToQR-${{needs.update-version.outputs.new_version}}.zip
+#
+#          chrome-webstore-upload
+
+  release-edge:
+    runs-on: ubuntu-latest
+    name: "Create TapToQR Edge Release"
+    needs:
+      [
+        build,
+        update-version
+      ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,8 +171,9 @@ jobs:
 
       - name: "Upload to Chrome Webstore"
         run: |-
+          cd TapToQR-addon
           chrome-webstore-upload \\
-            --source "TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip" \\
+            --source TapToQR-${{needs.update-version.outputs.new_version}}.zip \\
             --extension-id "ommdikomjapdndpedljobeecepeopjmp" \\
             --client-id ${{ secrets.CI_GOOGLE_CLIENT_ID }} \\
             --client-secret ${{ secrets.CI_GOOGLE_CLIENT_SECRET }} \\

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,6 @@ jobs:
       - name: Update version var
         id: write_version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.VAR_UPDATE_GITHUB }}
         run: |
           gh variable set VERSION --body "${{ steps.bump_version.outputs.new_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Bump version
         id: bump_version
-        if: ${{ !github.event.inputs.skip-update }}
+        if: ${{ github.event.inputs.skip-update == 'false' }}
         run: |
           # Retrieve the increment type from the GitHub Actions input
           increment="${{ inputs.release-type }}"
@@ -111,7 +111,7 @@ jobs:
 
       - name: Update version var
         id: write_version
-        if: ${{ !github.event.inputs.skip-update }}
+        if: ${{ github.event.inputs.skip-update == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.VAR_UPDATE_GITHUB }}
         run: |
@@ -129,7 +129,7 @@ jobs:
   release-github:
     runs-on: ubuntu-latest
     name: "Create TapToQR Github Release"
-    if: ${{ github.event.inputs.publish-github == true }}
+    if: ${{ github.event.inputs.publish-github == 'true' }}
     permissions: write-all
     needs:
       [
@@ -154,7 +154,7 @@ jobs:
   release-firefox:
     runs-on: ubuntu-latest
     name: "Create TapToQR Firefox Release"
-    if: ${{ github.event.inputs.publish-firefox == true }}
+    if: ${{ github.event.inputs.publish-firefox == 'true' }}
     needs:
       [
         build
@@ -178,7 +178,7 @@ jobs:
   release-chrome:
     runs-on: ubuntu-latest
     name: "Create TapToQR Chrome Release"
-    if: ${{ github.event.inputs.publish-chrome == true }}
+    if: ${{ github.event.inputs.publish-chrome == 'true' }}
     needs:
       [
         build
@@ -213,7 +213,7 @@ jobs:
   release-edge:
     runs-on: ubuntu-latest
     name: "Create TapToQR Edge Release"
-    if: ${{ github.event.inputs.publish-edge == true }}
+    if: ${{ github.event.inputs.publish-edge == 'true' }}
     needs:
       [
         build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,3 +197,10 @@ jobs:
 
       - name: Download Artifact
         uses: actions/download-artifact@v4
+
+      - uses: wdzeng/edge-addon@d4db1eea77297a24d799394dec87e8912e0902f9
+        with:
+          product-id: "1cc708c2-05e8-4339-9fdb-ddca04acf678"
+          zip-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          api-key: ${{ secrets.MICROSOFT_API_KEY }}
+          client-id: ${{ secrets.MICROSOFT_CLIENT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
     outputs:
       new_version: ${{ steps.bump_version.outputs.new_version }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Ensure branch is main
         if: github.ref != 'refs/heads/main'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,40 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v4
 
-      - uses: wdzeng/firefox-addon@1c933bcfc899dad45719bc23ec8c607d51bf8c06
-        with:
-          addon-guid: "taptoqr@moritzreis.dev"
-          xpi-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip
-          self-hosted: false
-          jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
-          jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}
+#      - uses: wdzeng/firefox-addon@1c933bcfc899dad45719bc23ec8c607d51bf8c06
+#        name: "Upload to Firefox Addon Store"
+#        with:
+#          addon-guid: "taptoqr@moritzreis.dev"
+#          xpi-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip
+#          self-hosted: false
+#          jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
+#          jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}
+
+  release-chrome:
+    runs-on: ubuntu-latest
+    name: "Create TapToQR Chrome Release"
+    permissions: write-all
+    needs:
+      [
+        build,
+        update-version
+      ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+
+      - name: "Setup Google Webstore CLI"
+        run: |
+          npm install -g chrome-webstore-upload-cli
+
+      - name: "Upload to Chrome Webstore"
+        run: |-
+          chrome-webstore-upload \\
+            --source "TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip" \\
+            --extension-id "ommdikomjapdndpedljobeecepeopjmp" \\
+            --client-id ${{ secrets.CI_GOOGLE_CLIENT_ID }} \\
+            --client-secret ${{ secrets.CI_GOOGLE_CLIENT_SECRET }} \\
+            --refresh-token ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,9 @@ jobs:
         update-version
       ]
 
-  release:
+  release-github:
     runs-on: ubuntu-latest
-    name: "Create TapToQR Release"
+    name: "Create TapToQR Github Release"
     permissions: write-all
     needs:
       [
@@ -140,7 +140,7 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v4
 
-      - uses: wdzeng/firefox-addon@a6c520c
+      - uses: wdzeng/firefox-addon@a6c520c479eb79861995faf3fa3e271c1b277820
         with:
           addon-guid: "taptoqr@moritzreis.dev"
           xpi-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Ensure branch is main
-        if: github.ref != 'refs/heads/main'
-        run: |
-          text="Publish a new version can only be done from the main branch."
-          echo "::error title=Wrong Branch::$text"
-          exit 1
+#      - name: Ensure branch is main
+#        if: github.ref != 'refs/heads/main'
+#        run: |
+#          text="Publish a new version can only be done from the main branch."
+#          echo "::error title=Wrong Branch::$text"
+#          exit 1
 
       - name: Read current version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: "Release TapToQR"
 on:
   workflow_dispatch:
     inputs:
+      skip-update:
+        description: "Skip the version update step"
+        required: false
+        default: false
       release-type:
         type: choice
         description: Which type of release to create?
@@ -12,6 +16,26 @@ on:
           - patch
           - minor
           - major
+      publish-firefox:
+        type: boolean
+        description: Should the Firefox Addon be published?
+        required: false
+        default: true
+      publish-chrome:
+        type: boolean
+        description: Should the Chrome Extension be published?
+        required: false
+        default: true
+      publish-edge:
+        type: boolean
+        description: Should the Edge Extension be published?
+        required: false
+        default: true
+      publish-github:
+        type: boolean
+        description: Should the Github Release be published?
+        required: false
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}
@@ -21,6 +45,7 @@ jobs:
   # Get the Current Version and Bump it depending on the release-type input
   update-version:
     name: "Update TapToQR Version"
+    if: ${{ !github.event.inputs.skip-update }}
     runs-on: ubuntu-latest
     permissions: write-all
     outputs:
@@ -29,12 +54,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-#      - name: Ensure branch is main
-#        if: github.ref != 'refs/heads/main'
-#        run: |
-#          text="Publish a new version can only be done from the main branch."
-#          echo "::error title=Wrong Branch::$text"
-#          exit 1
+      - name: Ensure branch is main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          text="Publish a new version can only be done from the main branch."
+          echo "::error title=Wrong Branch::$text"
+          exit 1
 
       - name: Read current version
         run: |
@@ -102,6 +127,7 @@ jobs:
   release-github:
     runs-on: ubuntu-latest
     name: "Create TapToQR Github Release"
+    if: ${{ github.event.inputs.publish-github }}
     permissions: write-all
     needs:
       [
@@ -115,18 +141,19 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v4
 
-#      - name: Create Release
-#        working-directory: './TapToQR-addon'
-#        env:
-#          GH_TOKEN: ${{github.token}}
-#        run: |
-#          echo "Creating release v${{needs.update-version.outputs.new_version}}"
-#          gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
-#          gh release upload v${{needs.update-version.outputs.new_version}} TapToQR-${{needs.update-version.outputs.new_version}}.zip
+      - name: Create Release
+        working-directory: './TapToQR-addon'
+        env:
+          GH_TOKEN: ${{github.token}}
+        run: |
+          echo "Creating release v${{needs.update-version.outputs.new_version}}"
+          gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
+          gh release upload v${{needs.update-version.outputs.new_version}} TapToQR-${{needs.update-version.outputs.new_version}}.zip
 
   release-firefox:
     runs-on: ubuntu-latest
     name: "Create TapToQR Firefox Release"
+    if: ${{ github.event.inputs.publish-firefox }}
     needs:
       [
         build,
@@ -139,18 +166,19 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v4
 
-#      - uses: wdzeng/firefox-addon@1c933bcfc899dad45719bc23ec8c607d51bf8c06
-#        name: "Upload to Firefox Addon Store"
-#        with:
-#          addon-guid: "taptoqr@moritzreis.dev"
-#          xpi-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip
-#          self-hosted: false
-#          jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
-#          jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}
+      - uses: wdzeng/firefox-addon@1c933bcfc899dad45719bc23ec8c607d51bf8c06
+        name: "Upload to Firefox Addon Store"
+        with:
+          addon-guid: "taptoqr@moritzreis.dev"
+          xpi-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          self-hosted: false
+          jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}
 
   release-chrome:
     runs-on: ubuntu-latest
     name: "Create TapToQR Chrome Release"
+    if: ${{ github.event.inputs.publish-chrome }}
     needs:
       [
         build,
@@ -174,18 +202,19 @@ jobs:
         run: |
           npm install -g chrome-webstore-upload-cli
 
-#      - name: "Upload to Chrome Webstore"
-#        run: |-
-#          cd TapToQR-addon
-#
-#          unzip TapToQR-${{needs.update-version.outputs.new_version}}.zip
-#          rm TapToQR-${{needs.update-version.outputs.new_version}}.zip
-#
-#          chrome-webstore-upload
+      - name: "Upload to Chrome Webstore"
+        run: |-
+          cd TapToQR-addon
+
+          unzip TapToQR-${{needs.update-version.outputs.new_version}}.zip
+          rm TapToQR-${{needs.update-version.outputs.new_version}}.zip
+
+          chrome-webstore-upload
 
   release-edge:
     runs-on: ubuntu-latest
     name: "Create TapToQR Edge Release"
+    if: ${{ github.event.inputs.publish-edge }}
     needs:
       [
         build,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,13 @@ jobs:
         build,
         update-version
       ]
+
+    env:
+      EXTENSION_ID: "ommdikomjapdndpedljobeecepeopjmp"
+      CLIENT_ID: ${{ secrets.CI_GOOGLE_CLIENT_ID }}
+      CLIENT_SECRET: ${{ secrets.CI_GOOGLE_CLIENT_SECRET }}
+      REFRESH_TOKEN: ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -173,13 +180,7 @@ jobs:
         run: |-
           cd TapToQR-addon
           
-          # unzip the artifact
           unzip TapToQR-${{needs.update-version.outputs.new_version}}.zip
-          ls -R
+          rm TapToQR-${{needs.update-version.outputs.new_version}}.zip
           
-          chrome-webstore-upload \\
-            --source TapToQR-${{needs.update-version.outputs.new_version}}.zip \\
-            --extension-id "ommdikomjapdndpedljobeecepeopjmp" \\
-            --client-id ${{ secrets.CI_GOOGLE_CLIENT_ID }} \\
-            --client-secret ${{ secrets.CI_GOOGLE_CLIENT_SECRET }} \\
-            --refresh-token ${{ secrets.CI_GOOGLE_REFRESH_TOKEN }}
+          chrome-webstore-upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-update:
+        type: boolean
         description: "Skip the version update step"
         required: false
         default: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,12 +115,9 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Create Release
+        working-directory: './TapToQR-addon'
         env:
           GH_TOKEN: ${{github.token}}
         run: |
-          ls -R
-          
-          # gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
-          
-          # Compress-Archive -Path .\AppPackages -DestinationPath .\AppPackages.zip
-          # gh release upload v${{needs.update-version.outputs.new_version}} .\AppPackages.zip
+          gh release create v${{needs.update-version.outputs.new_version}} --generate-notes
+          gh release upload v${{needs.update-version.outputs.new_version}} .\TapToQR-${{needs.update-version.outputs.new_version}}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v4
 
-      - uses: wdzeng/firefox-addon@a6c520c479eb79861995faf3fa3e271c1b277820
+      - uses: wdzeng/firefox-addon@1c933bcfc899dad45719bc23ec8c607d51bf8c06
         with:
           addon-guid: "taptoqr@moritzreis.dev"
           xpi-path: TapToQR-addon/TapToQR-${{needs.update-version.outputs.new_version}}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,12 +129,11 @@ jobs:
   release-github:
     runs-on: ubuntu-latest
     name: "Create TapToQR Github Release"
-    if: ${{ github.event.inputs.publish-github }}
+    if: ${{ github.event.inputs.publish-github == true }}
     permissions: write-all
     needs:
       [
-        build,
-        update-version
+        build
       ]
     steps:
       - name: Checkout code
@@ -155,11 +154,10 @@ jobs:
   release-firefox:
     runs-on: ubuntu-latest
     name: "Create TapToQR Firefox Release"
-    if: ${{ github.event.inputs.publish-firefox }}
+    if: ${{ github.event.inputs.publish-firefox == true }}
     needs:
       [
-        build,
-        update-version
+        build
       ]
     steps:
       - name: Checkout code
@@ -180,11 +178,10 @@ jobs:
   release-chrome:
     runs-on: ubuntu-latest
     name: "Create TapToQR Chrome Release"
-    if: ${{ github.event.inputs.publish-chrome }}
+    if: ${{ github.event.inputs.publish-chrome == true }}
     needs:
       [
-        build,
-        update-version
+        build
       ]
 
     env:
@@ -216,11 +213,10 @@ jobs:
   release-edge:
     runs-on: ubuntu-latest
     name: "Create TapToQR Edge Release"
-    if: ${{ github.event.inputs.publish-edge }}
+    if: ${{ github.event.inputs.publish-edge == true }}
     needs:
       [
-        build,
-        update-version
+        build
       ]
     steps:
       - name: Checkout code
@@ -228,6 +224,16 @@ jobs:
 
       - name: Download Artifact
         uses: actions/download-artifact@v4
+
+      - name: Prepare Artifact
+        run: |
+          cd TapToQR-addon
+          unzip TapToQR-${{needs.build.outputs.VERSION}}.zip
+          rm TapToQR-${{needs.build.outputs.VERSION}}.zip
+          FILE="manifest.json"
+          jq 'del(.browser_specific_settings)' "$FILE" > temp_manifest.json && mv temp_manifest.json "$FILE"
+          # zip again
+          zip -r TapToQR-${{needs.build.outputs.VERSION}}.zip ./*
 
       - uses: wdzeng/edge-addon@d4db1eea77297a24d799394dec87e8912e0902f9
         with:

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -37,8 +37,7 @@
     },
     "browser_specific_settings": {
         "gecko": {
-            "id": "taptoqr@moritzreis.dev",
-            "strict_min_version": "121.0"
+            "id": "taptoqr@moritzreis.dev"
         }
     }
 }

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "TapToQR",
-    "version": "1.1.0",
+    "version": "0.0.0",
     "description": "Instantly generate and share a QR code for the webpage you're currently viewing, making link sharing seamless and quick.",
     "author": "Moritz Reis",
     "icons": {
@@ -37,7 +37,8 @@
     },
     "browser_specific_settings": {
         "gecko": {
-            "id": "taptoqr@moritzreis.dev"
+            "id": "taptoqr@moritzreis.dev",
+            "strict_min_version": "121.0"
         }
     }
 }


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflows for building and releasing the TapToQR addon. The changes enhance the automation and flexibility of the release process by introducing new inputs and conditional steps.

### Workflow Enhancements:

* **Build Workflow (`.github/workflows/build.yml`):**
  * Added `outputs` to define the `VERSION` output for the build job, which captures the version of the addon being built. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R17-R21) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R39-R41)

* **Release Workflow (`.github/workflows/release.yml`):**
  * Introduced new inputs to control the release process, including options to skip the version update step and to determine whether to publish the addon to Firefox, Chrome, Edge, and GitHub. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R6-R10) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R20-R39)
  * Updated the version update job to conditionally skip the version bump based on the `skip-update` input. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R48-R56) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R70) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R114-R243)
  * Added new jobs for building the addon and creating releases for GitHub, Firefox, Chrome, and Edge, each with conditional execution based on the corresponding input.

### Manifest Update:

* **Addon Manifest (`addon/manifest.json`):**
  * Set the version to `0.0.0` to ensure it is dynamically updated during the release process.