### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,9 @@ jobs:
     runs-on: ubuntu-latest
     name: "Create TapToQR Edge Release"
     if: ${{ github.event.inputs.publish-edge == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
     needs:
       [
         build


### PR DESCRIPTION
Potential fix for [https://github.com/clFaster/TapToQR/security/code-scanning/6](https://github.com/clFaster/TapToQR/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the `release-edge` job. Based on the steps in the job, it primarily checks out code, downloads artifacts, and interacts with the Microsoft Edge Add-on API. The minimal permissions required are `contents: read` for accessing repository contents and `id-token: write` if the API interaction requires an OpenID Connect token. No unnecessary write permissions will be granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
