### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,8 @@ jobs:
     runs-on: ubuntu-latest
     name: "Create TapToQR Chrome Release"
     if: ${{ github.event.inputs.publish-chrome == 'true' }}
+    permissions:
+      contents: read
     needs:
       [
         build


### PR DESCRIPTION
Potential fix for [https://github.com/clFaster/TapToQR/security/code-scanning/5](https://github.com/clFaster/TapToQR/security/code-scanning/5)

The best way to fix the problem is to add a `permissions` block to the `release-chrome` job in `.github/workflows/release.yml`.  
- Since this job only checks out the code and downloads build artifacts, it likely only needs `contents: read`, which allows the job to access repository contents but not modify them.
- Place the block directly under the job and above any `needs` or `steps` section.
- This change should be made at line `179`, right after `runs-on: ubuntu-latest`, consistent with other jobs in the workflow.
- No changes to imports, methods, or definitions are necessary; this is a workflow configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
